### PR TITLE
Can now ask a server for its player count without disrupting the server

### DIFF
--- a/src/pymultiplayer/TCPserver.py
+++ b/src/pymultiplayer/TCPserver.py
@@ -52,6 +52,12 @@ class TCPMultiplayerServer:
             raise PortInUseError(self.port)
 
     async def proxy(self, websocket):
+        msg = loads(await websocket.recv())
+        if msg["type"] == "get_player_count":
+            await websocket.send(dumps({"type": "get_player_count", "content": len(self.clients)}))
+            await websocket.close()
+            return
+
         if len(self.clients)+1 > self.max_clients:
             await websocket.send(dumps({"type": "error", "content": "Server is full"}))
             await websocket.close()

--- a/src/pymultiplayer/__init__.py
+++ b/src/pymultiplayer/__init__.py
@@ -1,6 +1,7 @@
 from .TCPserver import TCPMultiplayerServer
 from .client import MultiplayerClient
-from .server_manager import ServerManager, get_servers, create_server
+from .server_manager import ServerManager
+from .functions import get_servers, create_server, get_player_count_of_server
 print("pymultiplayer by iamdeedz")
 print("https://www.github.com/iamdeedz/pymultiplayer")
 print("This library is currently a work in progress.")

--- a/src/pymultiplayer/client.py
+++ b/src/pymultiplayer/client.py
@@ -1,6 +1,6 @@
 import websockets, asyncio
 from .errors import ServerError, ServerClosedError, ServerUnreachableError
-from json import loads
+from json import loads, dumps
 from threading import Thread, Event
 
 
@@ -31,11 +31,17 @@ class MultiplayerClient:
 
             async with websockets.connect(uri) as websocket:
                 self.ws = websocket
+
+                # This message tells the server to continue processing this client as if they want to join (which they do)
+                # instead of returning the amount of players connected to the server
+                await self.ws.send(dumps({"type": ""}))
+
                 self.id = loads(await websocket.recv())["content"]
+
                 async for msg in self.ws:
                     await self._msg_handler(msg)
 
-                await self.ws.close()
+                await self.disconnect()
                 quit()
 
         except OSError:

--- a/src/pymultiplayer/functions.py
+++ b/src/pymultiplayer/functions.py
@@ -1,0 +1,35 @@
+import websockets
+from json import dumps, loads
+
+
+async def get_servers(ip, port):
+    async with websockets.connect(f"ws://{ip}:{port}") as websocket:
+        await websocket.send(dumps({"type": "get"}))
+        return_msg = loads(await websocket.recv())
+        await websocket.close()
+        return return_msg
+
+
+async def create_server(ip, port, parameters: dict):
+    async with websockets.connect(f"ws://{ip}:{port}") as websocket:
+        await websocket.send(dumps({"type": "create", "parameters": parameters}))
+        reply = loads(await websocket.recv())
+        await websocket.close()
+        return reply
+
+
+async def get_player_count_of_server(ip, port):
+    async with websockets.connect(f"ws://{ip}:{port}") as websocket:
+        msg = await websocket.recv()
+        uri = loads(msg)["content"]
+        if not uri.startswith("ws://"):
+            print("Invalid URI")
+            await websocket.close()
+            quit()
+
+        await websocket.close()
+
+    async with websockets.connect(uri) as websocket:
+        await websocket.send(dumps({"type": "get_player_count"}))
+        return_msg = loads(await websocket.recv())
+        return return_msg

--- a/src/pymultiplayer/server_manager.py
+++ b/src/pymultiplayer/server_manager.py
@@ -51,19 +51,3 @@ class ServerManager:
 
     def run(self):
         asyncio.run(self._run())
-
-
-async def get_servers(ip, port):
-    async with websockets.connect(f"ws://{ip}:{port}") as websocket:
-        await websocket.send(dumps({"type": "get"}))
-        return_msg = loads(await websocket.recv())
-        await websocket.close()
-        return return_msg
-
-
-async def create_server(ip, port, parameters: dict):
-    async with websockets.connect(f"ws://{ip}:{port}") as websocket:
-        await websocket.send(dumps({"type": "create", "parameters": parameters}))
-        reply = loads(await websocket.recv())
-        await websocket.close()
-        return reply


### PR DESCRIPTION
... using the `get_player_count_of_server` function. Also moved the `get_servers` and `create_server` functions to a new file called `functions.py` which also stores the new `get_player_count_of_server` function.

Closes #16